### PR TITLE
fix: handle int input converted to string when querying via url for number parameter in highest_measurement

### DIFF
--- a/web/models/highest_measurement.py
+++ b/web/models/highest_measurement.py
@@ -16,6 +16,14 @@ def get_highest_measurement(feature, number=10, groupby=None, **filters):
     Returns:
         list: A list of dictionaries containing the highest expressors of the feature.
     """
+    
+    if type(number) == str:
+        try:
+            number = int(number)
+        except:
+            print(f"Requested number '{number}' is not valid, using default 10")
+            number = 10
+            
     if groupby is None:
         groupby = []
     if "cell_type" not in groupby:


### PR DESCRIPTION
API call:
```
import requests
url = "https://api-disease.atlasapprox.org/v1/highest_measurement"

# Send parameters as JSON in the request body
params = {
    "feature": "CD19",
    "number": 30
}
response = requests.post(url, params=params)
data = response.json()
data
```
error: 
![image](https://github.com/user-attachments/assets/6b70aa83-614e-4cc4-9bb9-e3fdbabdd936)
