### PR TITLE
fix: Use correct data comparison in differential gene expression

### DIFF
--- a/web/api/v1/objects/differential_gene_expression.py
+++ b/web/api/v1/objects/differential_gene_expression.py
@@ -30,12 +30,18 @@ class DifferentialGeneExpression(Resource):
                 "unique_ids",
             ],
         )
+        
+        if "sex" in filters and "sex" not in groupby:
+            groupby = ["sex"] + groupby
+        
         feature = args.get("feature", None, type=str)
         number = int(request.args.get("top_n", default=0, type=int))
         if feature is not None and number > 0:
             abort(400, "Either feature or number must be provided, not both")
-        elif feature is None:
+        
+        if number == 0:
             number = 10
+
         method = args.get("method", "delta_fraction", type=str)
 
         diff_exp = get_diff_expression(

--- a/web/app.py
+++ b/web/app.py
@@ -35,6 +35,5 @@ CORS(app, resources=authorized_resources)
 
 # Main loop
 if __name__ == "__main__":
-    # app.run(debug=True)
-    app.run(host="0.0.0.0", port=5000)
-
+    app.run(debug=True)
+    # app.run(host="0.0.0.0", port=5000, debug=True)

--- a/web/models/differential_gene_expression.py
+++ b/web/models/differential_gene_expression.py
@@ -107,7 +107,7 @@ def get_diff_expression(
             # Ok, now there might be cell types that are missing in one of the conditions, so we need to
             # use the obs variable to filter these adata
             obs_namesd = list(set(obs_names) & set(adata_state.obs_names))
-            adata1d = adata_state[obs_namesd]
+            adata1d = adata_baseline[obs_namesd]
             adata2 = adata_state[obs_namesd]
 
             result_dataset_id = _diff_exp_adatas(

--- a/web/models/differential_gene_expression.py
+++ b/web/models/differential_gene_expression.py
@@ -40,6 +40,7 @@ def get_diff_expression(
 
     if groupby is None:
         groupby = []
+    # Ensure the comparison group has the same cell type and tissue (by default)
     if "cell_type" not in groupby:
         groupby = ["cell_type"] + groupby
         for i, name in enumerate(groupby):


### PR DESCRIPTION
There are a few issues with the diff_gene_exp api call:
1) The return dataframe from differential gene expression had all values as zero due to a typo in the code where it was comparing a dataset with itself (adata_state) instead of comparing baseline vs disease state data. 

2) The returned data frame does not show the sex and development stage info when user specify these on the filters
