### PR TITLE
Implement unique ID support for average, fraction, and dotplot queries

### DIFF
--- a/web/api/v1/exceptions.py
+++ b/web/api/v1/exceptions.py
@@ -9,7 +9,9 @@ from models.exceptions import (
     SomeFeaturesNotFoundError,
     DevelopmentStageNotFoundError,
     NoMatchingDatasetsError,
-    NoContrastingConditionsInADatasetError
+    NoContrastingConditionsInADatasetError,
+    ParamsConflictError,
+    UniqueIdNotFoundError
 )
 
 class FeatureStringFormatError(Exception):
@@ -136,6 +138,27 @@ def model_exceptions(func):
                 error={
                     "type": "no_results",
                     "filters_used": exc.filters
+                },
+            )
+
+        except ParamsConflictError:
+            abort(
+                400,
+                message="You can specify either unique_ids or metadata filters, not both.",
+                error={
+                    "type": "invalid_parameter_combination",
+                    "invalid_parameters": ["unique_ids", "metadata filters"],
+                },
+            )
+
+        except UniqueIdNotFoundError as exc:
+            abort(
+                400,
+                message=f"No unique id found that matches '{exc.unique_ids}'.",
+                error={
+                    "type": "invalid_parameter",
+                    "invalid_parameter": "unique_ids",
+                    "invalid_value": exc.unique_ids,
                 },
             )
             

--- a/web/api/v1/objects/differential_cell_type_abundance.py
+++ b/web/api/v1/objects/differential_cell_type_abundance.py
@@ -35,7 +35,7 @@ class DifferentialCellTypeAbundance(Resource):
                 "tissue",
                 "sex",
                 "development_stage",
-                "unique_ids",
+                # "unique_ids",
             ],
         )
 

--- a/web/api/v1/objects/differential_gene_expression.py
+++ b/web/api/v1/objects/differential_gene_expression.py
@@ -27,7 +27,7 @@ class DifferentialGeneExpression(Resource):
                 "tissue",
                 "sex",
                 "development_stage",
-                "unique_ids",
+                # "unique_ids",
             ],
         )
         

--- a/web/api/v1/utils.py
+++ b/web/api/v1/utils.py
@@ -13,7 +13,6 @@ def get_filter_kwargs(args, columns):
     kwargs = {}
     
     unique_ids = args.get("unique_ids")
-    print("get filter", args)
     
     if unique_ids:
         # Allow 'features' but not other metadata filters for specific functions, for example: average, dotplot ...
@@ -36,7 +35,7 @@ def get_filter_kwargs(args, columns):
                 unique_ids=unique_ids_list 
             )
         kwargs["unique_ids"] = unique_ids_list
-        return kwargs  # ✅ If `unique_ids` are used, skip processing other filters
+        return kwargs
             
     # If unique_ids are NOT provided, process metadata filters normally
     for column in columns:

--- a/web/models/exceptions.py
+++ b/web/models/exceptions.py
@@ -37,3 +37,13 @@ class NoContrastingConditionsInADatasetError(ValueError):
     def __init__(self, msg, filters):
         self.filters = filters
         super().__init__(msg)
+
+class ParamsConflictError(Exception):
+    def __init__(self, msg):
+        super().__init__(msg)
+        
+class UniqueIdNotFoundError(KeyError):
+    def __init__(self, msg, unique_ids):
+        self.unique_ids = unique_ids
+        super().__init__(self,msg)
+ 

--- a/web/models/measurement.py
+++ b/web/models/measurement.py
@@ -26,7 +26,8 @@ def get_measurement(features, kind, groupby=None, **filters):
     use_unique_ids = "unique_ids" in filters
 
     if use_unique_ids:
-        unique_ids = filters.pop("unique_ids")
+        # remove empty space
+        unique_ids = [uid.strip() for uid in filters.pop("unique_ids") if isinstance(uid, str)]
 
         # Retrieve metadata for the given `unique_ids`
         metadata = get_metadata()

--- a/web/models/metadata.py
+++ b/web/models/metadata.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pandas as pd
+import hashlib
 
 from config import configuration as config
 from models.baseline import get_differential_baseline
@@ -13,12 +14,21 @@ from models.exceptions import (
 
 metadata = None
 
+def generate_unique_id(row):
+    """Gnerate SA256 hash for a given row"""
+    row_string = ",".join(map(str, row))  # Convert row values to a single string
+    m = hashlib.md5()
+    m.update(row_string.encode("utf-8"))  # Update the hash with encoded row string
+    return m.hexdigest()  # Generate MD5 hash
 
 def load_metadata():
     """Cache metadata from the manifest file."""
     global metadata
     obs = pd.read_csv(config["paths"]["obs_metadata_file"])
     metadata = obs
+    
+    # Add unique_id column to metadata. Generate unique_id ONCE when starting the server and store it
+    obs["unique_id"] = obs.apply(generate_unique_id, axis=1)
 
 
 def get_metadata(**filters):
@@ -76,6 +86,9 @@ def get_metadata(**filters):
             filters=filters
         )
 
+    cols = ["unique_id"] + [col for col in filtered_metadata.columns if col != "unique_id"]
+    filtered_metadata = filtered_metadata[cols]
+    
     return filtered_metadata
 
 

--- a/web/models/metadata.py
+++ b/web/models/metadata.py
@@ -39,6 +39,9 @@ def get_metadata(**filters):
 
     keep = pd.Series(np.ones(len(metadata), dtype=bool), index=metadata.index)
     for key, value in filters.items():
+        if key == "unique_ids":
+            continue
+        
         # Boolean OR
         invert, value = value.startswith("!"), value.lstrip("!")
 


### PR DESCRIPTION
Key changes:
1. Querying average, fraction_detected, and dotplot using one or a list of unique IDs
2. Ensured correct metadata mapping per unique_id, including dataset_id, sex, cell_type, and tissue and disease condition

testing:
Tested with multiple unique IDs across different datasets
Each unique ID generates a separate data entry, even when sharing the same dataset.
Verified that average, fraction_detected, and dotplot queries return consistent data using both filters and unique IDs.