### PR TITLE
Add "include_normal" optional argument to average, dotplot, and fraction functions

### DIFF
--- a/web/api/v1/objects/dotplot.py
+++ b/web/api/v1/objects/dotplot.py
@@ -31,6 +31,8 @@ class DotPlot(Resource):
         feature_string = args.get("features", type=str)
         features = clean_feature_string(feature_string)
 
+        include_normal = args.get("include_normal", "").lower() == "true"
+        
         filters = get_filter_kwargs(
             args,
             [
@@ -46,6 +48,7 @@ class DotPlot(Resource):
         result = get_dotplot(
             features=features,
             groupby=groupby,
+            include_normal=include_normal,
             **filters,
         )
 

--- a/web/api/v1/objects/fraction_detected.py
+++ b/web/api/v1/objects/fraction_detected.py
@@ -30,6 +30,8 @@ class FractionDetected(Resource):
         groupby = get_groupby_args(args, ["tissue", "disease"])
         feature_string = args.get("features", type=str)
         features = clean_feature_string(feature_string)
+        
+        include_normal = args.get("include_normal", "").lower() == "true"
 
         filters = get_filter_kwargs(
             args,
@@ -46,6 +48,7 @@ class FractionDetected(Resource):
         result = get_fraction_detected(
             features,
             groupby=groupby,
+            include_normal=include_normal,
             **filters,
         )
         result = result.to_dict(orient="records")


### PR DESCRIPTION
Added `include_normal `optional argument to `average`, `dotplot`, and `fraction` functions. By default, it is False. 
When set to True, it includes normal (healthy) condition alongside the queried disease. 
This option only applies when a disease is explicitly specified, as queries without a disease already return both normal and disease conditions by default.